### PR TITLE
Fix typo in Install Hapi section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ module.exports = server;
 ```
 Install Hapi:
 ```
-npm inti -y && npm install hapi --save
+npm init -y && npm install hapi --save
 ```
 Run:
 ```


### PR DESCRIPTION
The typo would lead to errors for users that copy/paste the instructions.