### PR TITLE
update version of node to just "node" rather than legacy v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.4.0"
+ - "node"
 before_install:
   - pip install --user codecov
 after_success:


### PR DESCRIPTION
the reason that greenkeeper build #82 is failing is due to node version. 